### PR TITLE
fix: add showDataLabel input to heat map cells to display data labels on tiles

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/heat-map/heat-map-cell-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/heat-map/heat-map-cell-series.component.ts
@@ -50,7 +50,17 @@ interface Cell {
       [tooltipTitle]="tooltipTemplate ? undefined : tooltipText(c)"
       [tooltipTemplate]="tooltipTemplate"
       [tooltipContext]="{ series: c.series, name: c.label, value: c.data }"
-    ></svg:g>
+    >
+      <text *ngIf="showDataLabel" 
+        [attr.x]="c.x + c.width / 2" 
+        [attr.y]="c.y + c.height / 2" 
+        dy=".35em" 
+        text-anchor="middle" 
+        pointer-events="none" 
+        class="data-label">
+        {{ c.data }}
+      </text>
+    </svg:g>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false
@@ -65,6 +75,7 @@ export class HeatCellSeriesComponent implements OnChanges, OnInit {
   @Input() tooltipText: any;
   @Input() tooltipTemplate: TemplateRef<any>;
   @Input() animations: boolean = true;
+  @Input() showDataLabel: boolean = false;
 
   @Output() select: EventEmitter<DataItem> = new EventEmitter();
   @Output() activate: EventEmitter<DataItem> = new EventEmitter();


### PR DESCRIPTION
This PR addresses issue #1 by adding a new input property `showDataLabel` to the heat map cell series component. When enabled, it displays the actual data value in the center of each heat map tile, improving data readability without relying solely on tooltips.